### PR TITLE
Use setuptools-scm to derive version from git tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - name: Check out code from Github
         uses: actions/checkout@v6.0.2
+        with:
+          # setuptools-scm reads the version from the latest reachable git tag.
+          fetch-depth: 0
       - name: Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
         uses: actions/setup-python@v6.2.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,5 +67,7 @@ are listed in `.prettierignore` so prettier won't reformat them.
 
 ## Release
 
-Bump version in `pyproject.toml`, create a GitHub release with tag — CI auto-publishes
-to PyPI.
+Versioning is handled by `setuptools-scm` from git tags — do not edit a `version` field.
+Create a GitHub release with a `vX.Y.Z` tag; CI fetches full history, `setuptools-scm`
+resolves the version from the tag, and `release.yml` publishes to PyPI. Untagged dev
+builds get a `X.Y.Z.devN+g<sha>` version automatically.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,57 @@
 # contributors-txt
 
-Generate a list of contributors automatically from git data
+[![PyPI version](https://badge.fury.io/py/contributors-txt.svg)](https://badge.fury.io/py/contributors-txt)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/contributors-txt)](https://pypi.org/project/contributors-txt/)
+[![PyPI - License](https://img.shields.io/pypi/l/contributors-txt)](https://pypi.org/project/contributors-txt/)
+
+Generate a list of contributors automatically from git data.
+
+## Install
+
+```bash
+pip install contributors-txt
+```
+
+## Usage
+
+Run inside a git repository. Without an alias file, contributors are listed straight
+from `git shortlog`:
+
+```bash
+contributors-txt -o CONTRIBUTORS.txt
+```
+
+Pass an alias file to merge multiple emails under one name and assign teams:
+
+```bash
+contributors-txt -a aliases.json -o CONTRIBUTORS.txt
+```
+
+Add `--no-bots` to filter out GitHub Apps (`dependabot[bot]`, `pre-commit-ci[bot]`,
+`github-actions[bot]`, Copilot, Claude, …):
+
+```bash
+contributors-txt --no-bots -a aliases.json -o CONTRIBUTORS.txt
+```
+
+If the output file already exists it is updated in place: missing emails are added and
+new contributors are inserted in commit-count order, preserving any manual edits.
+
+## Alias file
+
+```json
+{
+  "pierre.sassoulas@gmail.com": {
+    "mails": ["pierre.sassoulas@gmail.com", "pierre.sassoulas@elum-energy.com"],
+    "name": "Pierre Sassoulas",
+    "team": "Maintainers"
+  }
+}
+```
+
+Two helpers ship alongside the main command:
+
+- `contributors-txt-normalize-configuration -a aliases.json` rewrites an alias file in
+  the canonical sorted form.
+- `contributors-txt-extract-comment <CONTRIBUTORS.txt> -a aliases.json` pulls free-text
+  comments from an existing CONTRIBUTORS file back into the alias file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,11 +2,11 @@
 build-backend = "setuptools.build_meta"
 requires = [
   "setuptools>=61.2",
+  "setuptools-scm>=8",
 ]
 
 [project]
 name = "contributors-txt"
-version = "1.0.1"
 description = "Generate a list of contributors automatically from git data"
 readme.content-type = "text/markdown"
 readme.file = "README.md"
@@ -26,6 +26,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
 ]
+dynamic = [ "version" ]
 dependencies = []
 optional-dependencies.test = [
   "coverage<8",
@@ -50,6 +51,8 @@ packages.find.exclude = [
   "tests.*",
 ]
 packages.find.namespaces = false
+
+[tool.setuptools_scm]
 
 [tool.ruff]
 target-version = "py39"


### PR DESCRIPTION
Switching the release flow off a hand-edited version field reduces the chance of forgetting the bump or shipping mismatched metadata. The tag becomes the single source of truth: CI builds whatever the tag says, and untagged dev builds get a self-describing X.Y.Z.devN+g<sha> version.

release.yml needs fetch-depth: 0 so setuptools-scm can see the tag during checkout.