### PR TITLE
Restore strict mypy after pytest-remaster migration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,14 +34,7 @@ repos:
         types: [python]
         args: []
         require_serial: true
-        additional_dependencies:
-          [
-            "types-pkg_resources==0.1.3",
-            "types-six",
-            "types-attrs",
-            "types-python-dateutil",
-            "types-typed-ast",
-          ]
+        additional_dependencies: ["pytest-remaster"]
   - repo: https://github.com/rbubley/mirrors-prettier
     rev: v3.8.3
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,9 +100,6 @@ overrides = [
   { module = [
     "pytest",
   ], ignore_missing_imports = true },
-  { module = [
-    "pytest_remaster",
-  ], ignore_missing_imports = true },
 ]
 
 [tool.pytest]

--- a/tests/test_create_content.py
+++ b/tests/test_create_content.py
@@ -10,7 +10,7 @@ from pytest_remaster import CaseData, GoldenMaster, discover_test_cases
 CASES_DIR = Path(__file__).parent / "create_content_cases"
 
 
-@pytest.mark.parametrize("case", discover_test_cases(CASES_DIR))  # type: ignore[untyped-decorator]
+@pytest.mark.parametrize("case", discover_test_cases(CASES_DIR))
 def test_create_content(case: CaseData, golden_master: GoldenMaster) -> None:
     shortlog = (case.input / "shortlog").read_text(encoding="utf8")
     flags_path = case.input / "flags.json"

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -10,7 +10,7 @@ from pytest_remaster import CaseData, GoldenMaster, discover_test_cases
 CASES_DIR = Path(__file__).parent / "extract_cases"
 
 
-@pytest.mark.parametrize("case", discover_test_cases(CASES_DIR))  # type: ignore[untyped-decorator]
+@pytest.mark.parametrize("case", discover_test_cases(CASES_DIR))
 def test_extract(
     case: CaseData,
     tmp_path: Path,

--- a/tests/test_get_aliases.py
+++ b/tests/test_get_aliases.py
@@ -10,7 +10,7 @@ from pytest_remaster import CaseData, GoldenMaster, discover_test_cases
 CASES_DIR = Path(__file__).parent / "get_aliases_cases"
 
 
-@pytest.mark.parametrize("case", discover_test_cases(CASES_DIR))  # type: ignore[untyped-decorator]
+@pytest.mark.parametrize("case", discover_test_cases(CASES_DIR))
 def test_get_aliases(
     case: CaseData,
     golden_master: GoldenMaster,

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -10,7 +10,7 @@ from pytest_remaster import CaseData, GoldenMaster, discover_test_cases
 CASES_DIR = Path(__file__).parent / "normalize_cases"
 
 
-@pytest.mark.parametrize("case", discover_test_cases(CASES_DIR))  # type: ignore[untyped-decorator]
+@pytest.mark.parametrize("case", discover_test_cases(CASES_DIR))
 def test_normalize(
     case: CaseData,
     tmp_path: Path,
@@ -25,7 +25,7 @@ def test_normalize(
     assert not recwarn
 
 
-@pytest.mark.parametrize("case", discover_test_cases(CASES_DIR))  # type: ignore[untyped-decorator]
+@pytest.mark.parametrize("case", discover_test_cases(CASES_DIR))
 def test_normalize_is_idempotent(
     case: CaseData,
     tmp_path: Path,


### PR DESCRIPTION
## Summary

PR #229 added two workarounds to keep `mypy --strict` quiet after migrating to `pytest-remaster`:

- `ignore_missing_imports = true` for the `pytest_remaster` module in `pyproject.toml`
- `# type: ignore[untyped-decorator]` on each `pytest.mark.parametrize` decorator

Both are now obsolete:

- `pytest-remaster` has shipped `py.typed` since 0.0.1 (the project pins no version, so the latest 0.0.5 is installed). With the marker present, mypy fully types `discover_test_cases` → `list[CaseData]`, so neither workaround is needed.
- Without these workarounds, mypy 1.20.2 in strict mode reports `Success: no issues found in 5 source files`.

## Test plan

- [x] `mypy tests/` → no issues
- [x] `pytest tests/` → 9 passed