### PR TITLE
Split modules by concern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,20 +18,26 @@ Activate the venv first: `source venv/bin/activate`
 
 ## Architecture
 
-- `contributors_txt/__main__.py` — CLI entry point, creates or updates CONTRIBUTORS
-  files
-- `contributors_txt/create_content.py` — Parses git shortlog, builds content from
-  scratch (sorted by commits descending)
+- `contributors_txt/__main__.py` — CLI entry point (`main`)
+- `contributors_txt/api.py` — `create_contributors_txt`, the public API (re-exported
+  from the package root): creates or updates a CONTRIBUTORS file
+- `contributors_txt/cli.py` — Argument parsing and logging setup shared by the CLI
+  commands
+- `contributors_txt/model.py` — Key types: `Alias` (email mappings) and `Person`
+  (contributor with commit count, name, email, team, comment) — both `NamedTuple`s
+- `contributors_txt/aliases.py` — Aliases JSON file IO (`get_aliases`,
+  `dump_normalized_aliases`)
+- `contributors_txt/git.py` — Runs `git shortlog` and parses its output into `Person`s
+- `contributors_txt/create_content.py` — Builds CONTRIBUTORS content from scratch
+  (sorted by commits descending)
 - `contributors_txt/update_content.py` — Updates existing files: adds missing emails,
-  inserts new contributors in commit-count order
+  inserts new contributors in commit-count order, auto-merges contributors appearing
+  under several names (and persists the merge in the aliases file)
 - `contributors_txt/extract_comment.py` — Extracts comments from existing CONTRIBUTORS
   files back into aliases
 - `contributors_txt/normalize.py` — Normalizes alias JSON files
-- `contributors_txt/const.py` — Constants (git command, excluded names/emails, bot
-  deny-list substrings activated by `--no-bots`)
-
-Key types: `Alias` (email mappings) and `Person` (contributor with commit count, name,
-email, team, comment) — both `NamedTuple`s in `create_content.py`.
+- `contributors_txt/const.py` — Constants (excluded names/emails, bot deny-list
+  substrings activated by `--no-bots`)
 
 ## Tests
 
@@ -44,6 +50,9 @@ tests/
   extract_cases/<case>/           contributors.txt, aliases.json, expected.json
   get_aliases_cases/<case>/       aliases.json, optional flags.json, expected.json
   normalize_cases/<case>/         input.json, expected.json
+  update_cases/<case>/            contributors.txt, aliases.json, shortlog,
+                                  optional flags.json, expected.txt
+                                  (+ expected_aliases.json with check_aliases)
 ```
 
 Add a new case by creating a subdirectory with the input files, then run
@@ -54,6 +63,12 @@ Add a new case by creating a subdirectory with the input files, then run
 
 - `{"no_bots": true}` — pass `no_bots=True` to `create_content`
 - `{"expect_warning": "<substring>"}` — assert a warning matching the substring
+- `{"expect_error": true}` — (update cases) assert `update_content` raises
+  `RuntimeError` and golden-master the error message as `expected.txt`
+- `{"check_aliases": true}` — (update cases) also compare the rewritten aliases file
+  against `expected_aliases.json`
+- `{"configuration_file": "<path>"}` — (update cases) aliases file path used in the
+  header and for saving auto-merged aliases
 
 Expected files are machine-formatted to match the runtime serializer byte-for-byte and
 are listed in `.prettierignore` so prettier won't reformat them.

--- a/contributors_txt/__init__.py
+++ b/contributors_txt/__init__.py
@@ -3,4 +3,4 @@
 
 __all__ = ["create_contributors_txt"]
 
-from contributors_txt.__main__ import create_contributors_txt
+from contributors_txt.api import create_contributors_txt

--- a/contributors_txt/__main__.py
+++ b/contributors_txt/__main__.py
@@ -3,15 +3,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
-from contributors_txt.cli import parse_args, set_logging
-from contributors_txt.create_content import (
-    create_content,
-    get_aliases,
-    get_shortlog_output,
-)
-from contributors_txt.update_content import update_content
+from contributors_txt.api import create_contributors_txt
+from contributors_txt.cli import parse_args
 
 
 def main(args: list[str] | None = None) -> None:
@@ -22,27 +15,6 @@ def main(args: list[str] | None = None) -> None:
         parsed_args.verbose,
         no_bots=parsed_args.no_bots,
     )
-
-
-def create_contributors_txt(
-    aliases_file: Path | str,
-    output: Path | str,
-    verbose: bool = False,
-    no_bots: bool = False,
-) -> None:
-    set_logging(verbose)
-    aliases = get_aliases(aliases_file)
-    shortlog_output = get_shortlog_output()
-    if Path(output).is_file():
-        content = update_content(
-            output, aliases, shortlog_output, str(aliases_file), no_bots=no_bots
-        )
-    else:
-        content = create_content(
-            aliases, shortlog_output, str(aliases_file), no_bots=no_bots
-        )
-    with open(output, "w", encoding="utf8") as f:
-        f.write(content)
 
 
 if __name__ == "__main__":

--- a/contributors_txt/aliases.py
+++ b/contributors_txt/aliases.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+import warnings
+from typing import TYPE_CHECKING
+
+from contributors_txt.const import DEFAULT_TEAM_ROLE
+from contributors_txt.model import Alias
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+
+def get_aliases(
+    aliases_file: Path | str | None, normalize: bool = False
+) -> list[Alias]:
+    aliases: list[Alias] = []
+    if aliases_file is None:
+        return aliases
+    with open(aliases_file, encoding="utf8") as f:
+        parsed_aliases = json.load(f)
+        for alias in parsed_aliases:
+            # logging.debug("Alias: %s", alias)
+            if isinstance(alias, str):
+                if "team" not in parsed_aliases[alias]:
+                    parsed_aliases[alias]["team"] = DEFAULT_TEAM_ROLE
+                if "name" in parsed_aliases[alias]:
+                    python_alias = Alias(
+                        authoritative_mail=alias, **parsed_aliases[alias]
+                    )
+                elif "authoritative_mail" in parsed_aliases[alias]:
+                    python_alias = Alias(name=alias, **parsed_aliases[alias])
+            else:
+                if not normalize:
+                    warnings.warn(
+                        "Using old copyrite format, you should use the configuration "
+                        "normalization with 'contributors-txt-normalize-configuration'",
+                        stacklevel=2,
+                    )
+                if "authoritative_mail" not in alias:
+                    alias["authoritative_mail"] = None
+                if "team" not in alias:
+                    alias["team"] = DEFAULT_TEAM_ROLE
+                python_alias = Alias(**alias)
+            # pylint: disable-next=possibly-used-before-assignment
+            aliases.append(python_alias)
+    return aliases
+
+
+def dump_normalized_aliases(aliases: list[Alias], output: Path | str) -> None:
+    content = get_new_aliases(aliases)
+    with open(output, "w", encoding="utf8") as f:
+        json.dump(content, f, indent=4, sort_keys=True, ensure_ascii=False)
+
+
+def get_new_aliases(
+    aliases: list[Alias],
+) -> dict[str | None, dict[str, Sequence[str] | str]]:
+    result = {}
+    for alias in aliases:
+        updated_alias = {
+            "mails": sorted(alias.mails),
+            "name": alias.name,
+        }
+        if alias.team != DEFAULT_TEAM_ROLE:
+            updated_alias["team"] = alias.team
+        if alias.comment:
+            updated_alias["comment"] = alias.comment
+        result[alias.authoritative_mail] = updated_alias
+    return result

--- a/contributors_txt/api.py
+++ b/contributors_txt/api.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from contributors_txt.aliases import get_aliases
+from contributors_txt.cli import set_logging
+from contributors_txt.create_content import create_content
+from contributors_txt.git import get_shortlog_output
+from contributors_txt.update_content import update_content
+
+
+def create_contributors_txt(
+    aliases_file: Path | str,
+    output: Path | str,
+    verbose: bool = False,
+    no_bots: bool = False,
+) -> None:
+    set_logging(verbose)
+    aliases = get_aliases(aliases_file)
+    shortlog_output = get_shortlog_output()
+    if Path(output).is_file():
+        content = update_content(
+            output, aliases, shortlog_output, str(aliases_file), no_bots=no_bots
+        )
+    else:
+        content = create_content(
+            aliases, shortlog_output, str(aliases_file), no_bots=no_bots
+        )
+    with open(output, "w", encoding="utf8") as f:
+        f.write(content)

--- a/contributors_txt/const.py
+++ b/contributors_txt/const.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 HERE = Path(__file__).parent
 DEFAULT_CONTRIBUTOR_PATH = "CONTRIBUTORS.txt"
-GIT_SHORTLOG = ["git", "shortlog", "--summary", "--numbered", "--email"]
 NO_SHOW_MAIL = ["bot@noreply.github.com"]
 NO_SHOW_NAME = ["root", "bot", "root@clnstor.am.local", "amdev@AMDEV-WS01.cisco.com"]
 DEFAULT_TEAM_ROLE = "Contributors"

--- a/contributors_txt/create_content.py
+++ b/contributors_txt/create_content.py
@@ -1,130 +1,15 @@
 from __future__ import annotations
 
-import json
 import logging
-import subprocess
-import warnings
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING
 
-from contributors_txt.const import (
-    DEFAULT_TEAM_ROLE,
-    GIT_SHORTLOG,
-    KNOWN_BOT_MAIL_SUBSTRINGS,
-    KNOWN_BOT_NAME_SUBSTRINGS,
-    NO_SHOW_MAIL,
-    NO_SHOW_NAME,
-)
+from contributors_txt.const import DEFAULT_TEAM_ROLE, NO_SHOW_MAIL, NO_SHOW_NAME
+from contributors_txt.git import persons_from_shortlog
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    from contributors_txt.model import Alias, Person
 
 LOGGER = logging.getLogger(__name__)
-
-
-class Alias(NamedTuple):
-    mails: list[str]
-    authoritative_mail: str | None
-    name: str
-    team: str
-    comment: str | None = None
-
-
-def get_aliases(
-    aliases_file: Path | str | None, normalize: bool = False
-) -> list[Alias]:
-    aliases: list[Alias] = []
-    if aliases_file is None:
-        return aliases
-    with open(aliases_file, encoding="utf8") as f:
-        parsed_aliases = json.load(f)
-        for alias in parsed_aliases:
-            # logging.debug("Alias: %s", alias)
-            if isinstance(alias, str):
-                if "team" not in parsed_aliases[alias]:
-                    parsed_aliases[alias]["team"] = DEFAULT_TEAM_ROLE
-                if "name" in parsed_aliases[alias]:
-                    python_alias = Alias(
-                        authoritative_mail=alias, **parsed_aliases[alias]
-                    )
-                elif "authoritative_mail" in parsed_aliases[alias]:
-                    python_alias = Alias(name=alias, **parsed_aliases[alias])
-            else:
-                if not normalize:
-                    warnings.warn(
-                        "Using old copyrite format, you should use the configuration "
-                        "normalization with 'contributors-txt-normalize-configuration'",
-                        stacklevel=2,
-                    )
-                if "authoritative_mail" not in alias:
-                    alias["authoritative_mail"] = None
-                if "team" not in alias:
-                    alias["team"] = DEFAULT_TEAM_ROLE
-                python_alias = Alias(**alias)
-            # pylint: disable-next=possibly-used-before-assignment
-            aliases.append(python_alias)
-    return aliases
-
-
-class Person(NamedTuple):
-    number_of_commits: int
-    name: str
-    mail: str | None
-    team: str
-    comment: str | None
-
-    def __gt__(self, other: Person) -> bool:  # type: ignore[override]
-        """Permit sorting contributors by number of commits."""
-        return self.number_of_commits.__gt__(other.number_of_commits)
-
-    def __add__(self, other: Person) -> Person:  # type: ignore[override]
-        assert self.name == other.name, f"{self.name} != {other.name}"
-        template = (
-            f"Mails are not the same: {self.mail} != {other.mail} "
-            f"for {self} vs {other}:\n"
-        )
-        template = self.get_template(template, other)
-        if self.team != DEFAULT_TEAM_ROLE:
-            template += f',\n"team": "{self.team}"'
-        template += "}"
-        assert other.mail is None or self.mail == other.mail, template
-        assert self.team == other.team
-        return Person(
-            self.number_of_commits + other.number_of_commits,
-            self.name,
-            self.mail,
-            self.team,
-            self.comment,
-        )
-
-    def get_template(self, template: str, other: Person | None = None) -> str:
-        template += f'"{self.mail}": '
-        template += "{"
-        mail = self.mail[1:-1] if self.mail is not None else ""
-        if other:
-            other_mail = other.mail[1:-1] if other.mail is not None else ""
-            return f"""{template}
-            "mails": ["{mail}","{other_mail}"],
-            "name": "{self.name}"
-"""
-        return f"""{template}
-            "mails": ["{mail}"],
-            "name": "{self.name}"
-"""
-
-    def __repr__(self) -> str:
-        # return f"{self.name=} {self.mail=} {self.number_of_commits=} {self.team=}"
-        return (
-            f"name={self.name} mail={self.mail} "
-            f"number_of_commits={self.number_of_commits} team={self.team}"
-        )
-
-    def __str__(self) -> str:
-        result = f"{self.name}"
-        if self.mail:
-            result += f" {self.mail}"
-        if self.comment:
-            result += f"{self.comment}"
-        return result
 
 
 def create_content(
@@ -143,32 +28,6 @@ def create_content(
     result += add_teams(persons)
     result += add_contributors(persons)
     return result
-
-
-def is_bot(name: str, mail: str | None) -> bool:
-    if any(substring in name for substring in KNOWN_BOT_NAME_SUBSTRINGS):
-        return True
-    if not mail:
-        return False
-    return any(substring in mail for substring in KNOWN_BOT_MAIL_SUBSTRINGS)
-
-
-def persons_from_shortlog(
-    aliases: list[Alias], shortlog_output: str, no_bots: bool = False
-) -> dict[str, Person]:
-    persons: dict[str, Person] = {}
-    for unparsed_person in shortlog_output.split("\n"):
-        if not unparsed_person:
-            # Empty line in git output
-            continue
-        # logging.debug("Handling %s", unparsed_person)
-        new_person = _parse_person(unparsed_person, aliases)
-        if no_bots and is_bot(new_person.name, new_person.mail):
-            continue
-        if new_person.name in persons:
-            new_person = persons[new_person.name] + new_person
-        persons[new_person.name] = new_person
-    return persons
 
 
 def add_contributors(persons: dict[str, Person]) -> str:
@@ -223,31 +82,3 @@ def get_teams(
             members.append(person)
             teams[person.team] = members
     return teams
-
-
-def get_shortlog_output() -> str:
-    git_shortlog = subprocess.run(GIT_SHORTLOG, capture_output=True, check=False)
-    return git_shortlog.stdout.decode("utf8")
-
-
-def _parse_person(unparsed_person: str, aliases: list[Alias]) -> Person:
-    splitted_person = unparsed_person.split()
-    number_of_commit, *names = splitted_person[:-1]
-    name = " ".join(names)
-    mail: str | None = splitted_person[-1][1:-1]
-    team = DEFAULT_TEAM_ROLE
-    comment: str | None = ""
-    if mail == "none@none":
-        mail = None
-    for alias in aliases:
-        if mail and mail in alias.mails:
-            # logging.debug("Found an alias: %s", mail)
-            mail = alias.authoritative_mail
-            name = alias.name
-            team = alias.team
-            comment = alias.comment
-            break
-    # logging.debug("Person is aliased to %s %s %s", number_of_commit, name, mail)
-    return Person(
-        int(number_of_commit), name, f"<{mail}>" if mail else None, team, comment
-    )

--- a/contributors_txt/extract_comment.py
+++ b/contributors_txt/extract_comment.py
@@ -6,10 +6,10 @@ import logging
 import re
 from pathlib import Path
 
+from contributors_txt.aliases import dump_normalized_aliases
 from contributors_txt.cli import add_default_arguments, set_logging
 from contributors_txt.const import DEFAULT_CONTRIBUTOR_PATH, DEFAULT_TEAM_ROLE
-from contributors_txt.create_content import Alias
-from contributors_txt.normalize import dump_normalized_aliases
+from contributors_txt.model import Alias
 
 LOGGER = logging.getLogger(__name__)
 

--- a/contributors_txt/git.py
+++ b/contributors_txt/git.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import subprocess
+
+from contributors_txt.const import (
+    DEFAULT_TEAM_ROLE,
+    KNOWN_BOT_MAIL_SUBSTRINGS,
+    KNOWN_BOT_NAME_SUBSTRINGS,
+)
+from contributors_txt.model import Alias, Person
+
+GIT_SHORTLOG = ["git", "shortlog", "--summary", "--numbered", "--email"]
+
+
+def get_shortlog_output() -> str:
+    git_shortlog = subprocess.run(GIT_SHORTLOG, capture_output=True, check=False)
+    return git_shortlog.stdout.decode("utf8")
+
+
+def is_bot(name: str, mail: str | None) -> bool:
+    if any(substring in name for substring in KNOWN_BOT_NAME_SUBSTRINGS):
+        return True
+    if not mail:
+        return False
+    return any(substring in mail for substring in KNOWN_BOT_MAIL_SUBSTRINGS)
+
+
+def persons_from_shortlog(
+    aliases: list[Alias], shortlog_output: str, no_bots: bool = False
+) -> dict[str, Person]:
+    persons: dict[str, Person] = {}
+    for unparsed_person in shortlog_output.split("\n"):
+        if not unparsed_person:
+            # Empty line in git output
+            continue
+        # logging.debug("Handling %s", unparsed_person)
+        new_person = _parse_person(unparsed_person, aliases)
+        if no_bots and is_bot(new_person.name, new_person.mail):
+            continue
+        if new_person.name in persons:
+            new_person = persons[new_person.name] + new_person
+        persons[new_person.name] = new_person
+    return persons
+
+
+def _parse_person(unparsed_person: str, aliases: list[Alias]) -> Person:
+    splitted_person = unparsed_person.split()
+    number_of_commit, *names = splitted_person[:-1]
+    name = " ".join(names)
+    mail: str | None = splitted_person[-1][1:-1]
+    team = DEFAULT_TEAM_ROLE
+    comment: str | None = ""
+    if mail == "none@none":
+        mail = None
+    for alias in aliases:
+        if mail and mail in alias.mails:
+            # logging.debug("Found an alias: %s", mail)
+            mail = alias.authoritative_mail
+            name = alias.name
+            team = alias.team
+            comment = alias.comment
+            break
+    # logging.debug("Person is aliased to %s %s %s", number_of_commit, name, mail)
+    return Person(
+        int(number_of_commit), name, f"<{mail}>" if mail else None, team, comment
+    )

--- a/contributors_txt/model.py
+++ b/contributors_txt/model.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from contributors_txt.const import DEFAULT_TEAM_ROLE
+
+
+class Alias(NamedTuple):
+    mails: list[str]
+    authoritative_mail: str | None
+    name: str
+    team: str
+    comment: str | None = None
+
+
+class Person(NamedTuple):
+    number_of_commits: int
+    name: str
+    mail: str | None
+    team: str
+    comment: str | None
+
+    def __gt__(self, other: Person) -> bool:  # type: ignore[override]
+        """Permit sorting contributors by number of commits."""
+        return self.number_of_commits.__gt__(other.number_of_commits)
+
+    def __add__(self, other: Person) -> Person:  # type: ignore[override]
+        assert self.name == other.name, f"{self.name} != {other.name}"
+        template = (
+            f"Mails are not the same: {self.mail} != {other.mail} "
+            f"for {self} vs {other}:\n"
+        )
+        template = self.get_template(template, other)
+        if self.team != DEFAULT_TEAM_ROLE:
+            template += f',\n"team": "{self.team}"'
+        template += "}"
+        assert other.mail is None or self.mail == other.mail, template
+        assert self.team == other.team
+        return Person(
+            self.number_of_commits + other.number_of_commits,
+            self.name,
+            self.mail,
+            self.team,
+            self.comment,
+        )
+
+    def get_template(self, template: str, other: Person | None = None) -> str:
+        template += f'"{self.mail}": '
+        template += "{"
+        mail = self.mail[1:-1] if self.mail is not None else ""
+        if other:
+            other_mail = other.mail[1:-1] if other.mail is not None else ""
+            return f"""{template}
+            "mails": ["{mail}","{other_mail}"],
+            "name": "{self.name}"
+"""
+        return f"""{template}
+            "mails": ["{mail}"],
+            "name": "{self.name}"
+"""
+
+    def __repr__(self) -> str:
+        # return f"{self.name=} {self.mail=} {self.number_of_commits=} {self.team=}"
+        return (
+            f"name={self.name} mail={self.mail} "
+            f"number_of_commits={self.number_of_commits} team={self.team}"
+        )
+
+    def __str__(self) -> str:
+        result = f"{self.name}"
+        if self.mail:
+            result += f" {self.mail}"
+        if self.comment:
+            result += f"{self.comment}"
+        return result

--- a/contributors_txt/normalize.py
+++ b/contributors_txt/normalize.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
-import json
 import logging
 from typing import TYPE_CHECKING
 
+from contributors_txt.aliases import dump_normalized_aliases, get_aliases
 from contributors_txt.cli import parse_args, set_logging
-from contributors_txt.const import DEFAULT_TEAM_ROLE
-from contributors_txt.create_content import Alias, get_aliases
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
     from pathlib import Path
 
 LOGGER = logging.getLogger(__name__)
@@ -31,26 +28,3 @@ def normalize_configuration(
     aliases = get_aliases(aliases_file, normalize=True)
     set_logging(verbose)
     dump_normalized_aliases(aliases, output)
-
-
-def dump_normalized_aliases(aliases: list[Alias], output: Path | str) -> None:
-    content = get_new_aliases(aliases)
-    with open(output, "w", encoding="utf8") as f:
-        json.dump(content, f, indent=4, sort_keys=True, ensure_ascii=False)
-
-
-def get_new_aliases(
-    aliases: list[Alias],
-) -> dict[str | None, dict[str, Sequence[str] | str]]:
-    result = {}
-    for alias in aliases:
-        updated_alias = {
-            "mails": sorted(alias.mails),
-            "name": alias.name,
-        }
-        if alias.team != DEFAULT_TEAM_ROLE:
-            updated_alias["team"] = alias.team
-        if alias.comment:
-            updated_alias["comment"] = alias.comment
-        result[alias.authoritative_mail] = updated_alias
-    return result

--- a/contributors_txt/update_content.py
+++ b/contributors_txt/update_content.py
@@ -5,15 +5,14 @@ import logging
 import re
 from pathlib import Path
 
+from contributors_txt.aliases import dump_normalized_aliases
 from contributors_txt.create_content import (
-    Alias,
-    Person,
     get_teams,
     line_for_person,
     person_should_be_shown,
-    persons_from_shortlog,
 )
-from contributors_txt.normalize import dump_normalized_aliases
+from contributors_txt.git import persons_from_shortlog
+from contributors_txt.model import Alias, Person
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/test_get_aliases.py
+++ b/tests/test_get_aliases.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 import pytest
-from contributors_txt.create_content import get_aliases
+from contributors_txt.aliases import get_aliases
 from pytest_remaster import CaseData, GoldenMaster, discover_test_cases
 
 CASES_DIR = Path(__file__).parent / "get_aliases_cases"

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -5,7 +5,7 @@ import shutil
 from pathlib import Path
 
 import pytest
-from contributors_txt.create_content import get_aliases
+from contributors_txt.aliases import get_aliases
 from contributors_txt.update_content import update_content
 from pytest_remaster import CaseData, GoldenMaster, discover_test_cases
 


### PR DESCRIPTION
Follow-up to #249, as discussed there: `create_content.py` was holding five unrelated concerns (domain types, aliases JSON IO, git subprocess, shortlog parsing, rendering) and `__main__.py` held the public API.

New layout:

| Module | Content |
|---|---|
| `model.py` | `Person` and `Alias` types |
| `aliases.py` | aliases file IO: `get_aliases`, `dump_normalized_aliases`, `get_new_aliases` |
| `git.py` | `git shortlog` subprocess and parsing into `Person`s |
| `create_content.py` | rendering only |
| `api.py` | `create_contributors_txt`, re-exported unchanged from the package root |
| `__main__.py` | CLI entry point only |

Pure moves — no behavior change. The public import (`from contributors_txt import create_contributors_txt`) and all three console scripts are unchanged.

Side effect: `python -m contributors_txt` no longer emits the runpy `RuntimeWarning` that came from `__init__.py` importing `__main__`.

CLAUDE.md architecture and test-case docs updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)